### PR TITLE
Fix admin panel slug handling

### DIFF
--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -63,7 +63,6 @@ export default function AdminDashboard() {
   const { toast } = useToast();
   const [selectedTab, setSelectedTab] = useState<'articles' | 'create' | 'prompts' | 'newsletter' | 'hackathon'>('articles');
   const [editingArticle, setEditingArticle] = useState<ArticleMeta | null>(null);
-  const [copiedPrompt, setCopiedPrompt] = useState(false);
   
   // Form state for creating/editing articles
   const [formData, setFormData] = useState({
@@ -111,11 +110,22 @@ export default function AdminDashboard() {
   // Handle form input changes
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
+
+    if (name === 'slug') {
+      const slug = value
+        .toLowerCase()
+        .replace(/[^\w\s-]/g, '')
+        .replace(/\s+/g, '-');
+      setFormData(prev => ({ ...prev, slug }));
+      return;
+    }
+
     setFormData(prev => ({ ...prev, [name]: value }));
-    
+
     // Auto-generate slug from title if slug field is empty
     if (name === 'title' && !formData.slug) {
-      const slug = value.toLowerCase()
+      const slug = value
+        .toLowerCase()
         .replace(/[^\w\s-]/g, '')
         .replace(/\s+/g, '-');
       setFormData(prev => ({ ...prev, slug }));

--- a/client/src/pages/admin/ArticleEditor.tsx
+++ b/client/src/pages/admin/ArticleEditor.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useRoute } from 'wouter';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient, UseQueryOptions } from '@tanstack/react-query';
 import { Article } from '@shared/types';
 import Container from '@/components/layout/Container';
 import { Card, CardContent } from '@/components/ui/card';
@@ -40,7 +40,7 @@ export default function ArticleEditor() {
         });
       }
     }
-  });
+  } as UseQueryOptions<Article>);
 
   // Update article mutation
   const updateArticle = useMutation({


### PR DESCRIPTION
## Summary
- sanitize slug when editing or typing
- remove unused prompt copy state
- fix types for article query

## Testing
- `npm run check` *(fails: Property 'slug' is missing in type etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68400a1e9c2083308c51ec28144af039