### PR TITLE
Fix nodemailer transport method

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -307,7 +307,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   async function sendHackathonWelcomeEmail(email: string) {
     try {
       console.log('📮 Configurazione trasporto email per hackathon...');
-      const transporter = nodemailer.createTransporter({
+      const transporter = nodemailer.createTransport({
         host: process.env.SMTP_HOST,
         port: Number(process.env.SMTP_PORT) || 587,
         secure: false,


### PR DESCRIPTION
## Summary
- correct nodemailer API usage in `sendHackathonWelcomeEmail`

## Testing
- `npm run check` *(fails: tsc compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68401170d7648330877b4c8e577ba5ce