### PR TITLE
Handle uploads path on Render

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -152,8 +152,11 @@ app.use((req, res, next) => {
 function serveStaticFiles(app: express.Express) {
   const distPath = path.resolve(process.cwd(), "dist/public");
   
-  // Configurazione per servire i file uploads
-  const uploadsDir = process.env.NODE_ENV === 'production' ? '/tmp/uploads' : path.join(process.cwd(), 'public', 'uploads');
+  // Configurazione per servire i file uploads.
+  // Su Render il filesystem è in sola lettura, quindi serviamo i file da /tmp.
+  const uploadsDir = (process.env.NODE_ENV === 'production' || process.env.RENDER)
+    ? '/tmp/uploads'
+    : path.join(process.cwd(), 'public', 'uploads');
   
   // Middleware per servire file uploads
   app.use('/uploads', express.static(uploadsDir));

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -17,8 +17,12 @@ const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
 const ADMIN_USERNAME = process.env.ADMIN_USERNAME || 'admin';
 const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'admin123';
 
-// Configurazione multer per usare /tmp in produzione e public/uploads in locale
-const uploadsDir = process.env.NODE_ENV === 'production' ? '/tmp/uploads' : path.join('public', 'uploads');
+// Configurazione della directory uploads.
+// Su Render il filesystem dell'app è in sola lettura, quindi usiamo sempre /tmp.
+// Rileviamo l'ambiente Render tramite la variabile d'ambiente RENDER.
+const uploadsDir = (process.env.NODE_ENV === 'production' || process.env.RENDER)
+  ? '/tmp/uploads'
+  : path.join('public', 'uploads');
 
 // Assicuriamoci che la directory esista (solo se siamo in grado di crearla)
 try {


### PR DESCRIPTION
## Summary
- adjust uploads directory detection to always use `/tmp` when on Render
- update static file serving code accordingly

## Testing
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840382e4c7083308885a3a0fe84b86d