### PR TITLE
Add neon theme toggle

### DIFF
--- a/client/src/components/ThemeToggle.tsx
+++ b/client/src/components/ThemeToggle.tsx
@@ -1,27 +1,31 @@
-import { Moon, Sun } from 'lucide-react';
-import { useTheme } from '@/hooks/use-theme';
+import { Moon, Sun, Sparkles } from 'lucide-react';
+import { useTheme, Theme } from '@/hooks/use-theme';
 import { Button } from '@/components/ui/button';
 
 export default function ThemeToggle() {
   const { theme, setTheme } = useTheme();
-  
+
   const toggleTheme = () => {
-    setTheme(theme === 'dark' ? 'light' : 'dark');
+    const order: Theme[] = ['dark', 'light', 'neon'];
+    const next = order[(order.indexOf(theme) + 1) % order.length];
+    setTheme(next);
   };
   
+  const icons = {
+    dark: <Sun className="h-5 w-5" />,
+    light: <Moon className="h-5 w-5" />,
+    neon: <Sparkles className="h-5 w-5" />,
+  } as const;
+
   return (
-    <Button 
-      variant="ghost" 
-      size="icon" 
-      onClick={toggleTheme} 
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleTheme}
       className="p-2 rounded-md text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 focus:outline-none"
-      aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} theme`}
+      aria-label="Toggle theme"
     >
-      {theme === 'dark' ? (
-        <Sun className="h-5 w-5" />
-      ) : (
-        <Moon className="h-5 w-5" />
-      )}
+      {icons[theme]}
     </Button>
   );
 }

--- a/client/src/hooks/use-theme.tsx
+++ b/client/src/hooks/use-theme.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useState } from 'react';
 
-type Theme = 'light' | 'dark';
+export type Theme = 'light' | 'dark' | 'neon';
 
 interface ThemeContextType {
   theme: Theme;
@@ -33,7 +33,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     const root = window.document.documentElement;
     
     // Remove the previous theme class
-    root.classList.remove('light', 'dark');
+    root.classList.remove('light', 'dark', 'neon');
     
     // Add the current theme class
     root.classList.add(theme);

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -330,6 +330,40 @@
   --radius: 0.5rem;
 }
 
+/* Light theme variables */
+.light {
+  color-scheme: light;
+  --background: 0 0% 100%;
+  --foreground: 0 0% 0%;
+  --card: 0 0% 98%;
+  --card-foreground: 0 0% 10%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 0 0% 10%;
+  --muted: 0 0% 90%;
+  --muted-foreground: 0 0% 40%;
+  --border: 0 0% 80%;
+  --input: 0 0% 95%;
+  --primary: 217 91% 60%;
+  --secondary: 217 91% 60%;
+  --accent: 191 97% 63%;
+  --destructive: 0 70% 50%;
+  --ring: 217 91% 60%;
+}
+
+/* Futuristic neon theme variables */
+.neon {
+  color-scheme: dark;
+  --background: 240 6% 8%;
+  --foreground: 0 0% 100%;
+  --card: 240 6% 12%;
+  --card-foreground: 0 0% 100%;
+  --primary: 295 100% 50%;
+  --secondary: 166 100% 50%;
+  --accent: 195 100% 50%;
+  --ring: 195 100% 50%;
+}
+
+/* Default dark mode */
 /* Only dark mode - overriding any light mode */
 html {
   color-scheme: dark;

--- a/client/src/pages/preferences.tsx
+++ b/client/src/pages/preferences.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Theme } from '@/hooks/use-theme';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import Container from '@/components/layout/Container';
 import { Helmet } from 'react-helmet';
@@ -46,7 +47,7 @@ export default function PreferencesPage() {
     },
   });
 
-  const [theme, setTheme] = useState('light');
+  const [theme, setTheme] = useState<Theme>('light');
   const [emailNotifications, setEmailNotifications] = useState(false);
   const [categories, setCategories] = useState<string[]>([]);
   const [success, setSuccess] = useState('');
@@ -106,6 +107,10 @@ export default function PreferencesPage() {
               <label className="flex items-center gap-2">
                 <input type="radio" name="theme" value="dark" checked={theme === 'dark'} onChange={() => setTheme('dark')} />
                 <span>Scuro</span>
+              </label>
+              <label className="flex items-center gap-2">
+                <input type="radio" name="theme" value="neon" checked={theme === 'neon'} onChange={() => setTheme('neon')} />
+                <span>Neon</span>
               </label>
             </div>
           </div>

--- a/client/src/types/user.ts
+++ b/client/src/types/user.ts
@@ -1,5 +1,5 @@
 export interface UserPreferences {
-  theme: 'light' | 'dark';
+  theme: 'light' | 'dark' | 'neon';
   language: string;
   notifications: boolean;
 }


### PR DESCRIPTION
## Summary
- export `Theme` type and include a new `neon` option
- add light and neon theme variables to Tailwind CSS index
- cycle through dark → light → neon in `ThemeToggle`
- support neon theme in preferences page
- expand allowed theme values in `UserPreferences`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6840383f367083308b204c462c59e05c