### PR TITLE
Fix admin API auth and newsletter fallback

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -18,6 +18,7 @@ import ReadingProgress from "@/components/ui/reading-progress";
 import ParticleBackground from "@/components/ui/particle-background";
 import AdminLogin from "@/pages/AdminLogin";
 import ProtectedRoute from "@/components/ProtectedRoute";
+import ArticleEditor from "@/pages/admin/ArticleEditor";
 import TagPage from "@/pages/tag";
 import CategoryPage from "@/pages/category";
 import PreferencesPage from '@/pages/preferences';
@@ -122,6 +123,11 @@ function App() {
             <Route path="/admin/newsletter">
               <ProtectedRoute>
                 <Newsletter />
+              </ProtectedRoute>
+            </Route>
+            <Route path="/admin/articles/:slug">
+              <ProtectedRoute>
+                <ArticleEditor />
               </ProtectedRoute>
             </Route>
             <Route path="/tag/:tag" component={TagPage} />

--- a/client/src/pages/admin/ArticleEditor.tsx
+++ b/client/src/pages/admin/ArticleEditor.tsx
@@ -50,10 +50,12 @@ export default function ArticleEditor() {
   // Update article mutation
   const updateArticle = useMutation({
     mutationFn: async (data: typeof formData) => {
+      const token = localStorage.getItem('adminToken');
       const response = await fetch(`/api/admin/articles/${slug}`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
+          ...(token ? { 'Authorization': `Bearer ${token}` } : {})
         },
         body: JSON.stringify({
           ...data,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -24,6 +24,24 @@ const uploadsDir = (process.env.NODE_ENV === 'production' || process.env.RENDER)
   ? '/tmp/uploads'
   : path.join('public', 'uploads');
 
+// Utilità per file newsletter e campagne quando il DB non è configurato
+const isProd = process.env.NODE_ENV === 'production';
+const hasDb = !!process.env.DATABASE_URL;
+const newsletterFilePath = (isProd && !hasDb)
+  ? path.join('/tmp', 'newsletter.json')
+  : path.join('content', 'newsletter.json');
+const newsletterCampaignsPath = (isProd && !hasDb)
+  ? path.join('/tmp', 'newsletter-campaigns.json')
+  : path.join('content', 'newsletter-campaigns.json');
+
+// Percorsi per file Hackathon quando non c'è un database configurato
+const hackathonDaysPath = (isProd && !hasDb)
+  ? path.join('/tmp', 'hackathon-days.json')
+  : path.join('content', 'hackathon-days.json');
+const hackathonSubscribersPath = (isProd && !hasDb)
+  ? path.join('/tmp', 'hackathon-subscribers.json')
+  : path.join('content', 'hackathon-subscribers.json');
+
 // Assicuriamoci che la directory esista (solo se siamo in grado di crearla)
 try {
   if (!fsSync.existsSync(uploadsDir)) {
@@ -204,14 +222,14 @@ export async function registerRoutes(app: Express): Promise<Server> {
         // SVILUPPO: Usa file JSON
         console.log('📁 [DEV] Usando sistema file JSON per iscrizione:', email);
         
-        const filePath = path.join('content', 'newsletter.json');
+        const filePath = newsletterFilePath;
         let emails: string[] = [];
-        
-        // Assicurati che la directory content esista
-        const contentDir = path.join('content');
-        if (!fsSync.existsSync(contentDir)) {
-          fsSync.mkdirSync(contentDir, { recursive: true });
-          console.log('✅ [DEV] Directory content creata');
+
+        // Assicurati che la directory esista solo se usiamo path locali
+        const dir = path.dirname(filePath);
+        if (!fsSync.existsSync(dir)) {
+          fsSync.mkdirSync(dir, { recursive: true });
+          console.log(`✅ [DEV] Directory creata: ${dir}`);
         }
         
         // Leggi file esistente
@@ -856,7 +874,7 @@ ${content}`;
         // SVILUPPO: Usa file JSON
         console.log('📁 [DEV] Caricando iscritti da file per API pubblica');
         
-        const filePath = path.join('content', 'newsletter.json');
+        const filePath = newsletterFilePath;
         let emails: string[] = [];
         
         try {
@@ -912,7 +930,7 @@ ${content}`;
         // SVILUPPO: Usa file JSON
         console.log('📁 [DEV] Usando file JSON per iscritti');
         
-        const filePath = path.join('content', 'newsletter.json');
+        const filePath = newsletterFilePath;
         let emails: string[] = [];
         
         try {
@@ -976,7 +994,7 @@ ${content}`;
         // SVILUPPO: Usa file JSON
         console.log('📁 [DEV] Cancellando iscritto da file JSON:', email);
         
-        const filePath = path.join('content', 'newsletter.json');
+        const filePath = newsletterFilePath;
         let emails: string[] = [];
         
         try {
@@ -1013,7 +1031,7 @@ ${content}`;
   apiRouter.get('/admin/newsletter/campaigns', authMiddleware, adminMiddleware, async (req: Request, res: Response) => {
     try {
       // Per ora usiamo un file JSON semplice per le campagne
-      const campaignsPath = path.join('content', 'newsletter-campaigns.json');
+      const campaignsPath = newsletterCampaignsPath;
       let campaigns = [];
       
       try {
@@ -1042,7 +1060,7 @@ ${content}`;
         return res.status(400).json({ error: 'Subject e content sono obbligatori' });
       }
 
-      const campaignsPath = path.join('content', 'newsletter-campaigns.json');
+      const campaignsPath = newsletterCampaignsPath;
       let campaigns = [];
       
       try {
@@ -1084,7 +1102,7 @@ ${content}`;
       console.log('🚀 [CAMPAIGN] Avvio invio campagna:', campaignId);
 
       // Carica campagne
-      const campaignsPath = path.join('content', 'newsletter-campaigns.json');
+      const campaignsPath = newsletterCampaignsPath;
       let campaigns = [];
       
       try {
@@ -1108,7 +1126,7 @@ ${content}`;
       console.log('📧 [CAMPAIGN] Campagna trovata:', campaign.subject);
       
       // Carica subscribers
-      const subscribersPath = path.join('content', 'newsletter.json');
+      const subscribersPath = newsletterFilePath;
       let emails: string[] = [];
       
       try {
@@ -1278,7 +1296,7 @@ ${content}`;
       console.log('🔄 [CAMPAIGN] Reset campagna:', campaignId);
 
       // Carica campagne
-      const campaignsPath = path.join('content', 'newsletter-campaigns.json');
+      const campaignsPath = newsletterCampaignsPath;
       let campaigns = [];
       
       try {
@@ -1333,7 +1351,7 @@ ${content}`;
   apiRouter.get('/admin/newsletter/stats', authMiddleware, adminMiddleware, async (req: Request, res: Response) => {
     try {
       // Conta iscritti
-      const subscribersPath = path.join('content', 'newsletter.json');
+      const subscribersPath = newsletterFilePath;
       let emails: string[] = [];
       
       try {
@@ -1346,7 +1364,7 @@ ${content}`;
       }
 
       // Conta campagne
-      const campaignsPath = path.join('content', 'newsletter-campaigns.json');
+      const campaignsPath = newsletterCampaignsPath;
       let campaigns = [];
       
       try {
@@ -1492,7 +1510,7 @@ ${content}`;
       console.log('🔍 [DEBUG] Richiesta debug lista iscritti newsletter');
       
       // Sistema principale: file JSON
-      const filePath = path.join('content', 'newsletter.json');
+      const filePath = newsletterFilePath;
       let emails: string[] = [];
       
       try {
@@ -1537,7 +1555,7 @@ ${content}`;
     try {
       console.log("🔍 [HACKATHON] Richiesta giorni hackathon ricevuta");
       
-      const hackathonFile = path.join('content', 'hackathon-days.json');
+      const hackathonFile = hackathonDaysPath;
       
       try {
         const data = await fs.readFile(hackathonFile, 'utf-8');
@@ -1594,7 +1612,7 @@ ${content}`;
       
       console.log(`🔄 [HACKATHON] Aggiornamento giorno ${dayNumber}:`, updatedDay);
       
-      const hackathonFile = path.join('content', 'hackathon-days.json');
+      const hackathonFile = hackathonDaysPath;
       
       try {
         const data = await fs.readFile(hackathonFile, 'utf-8');
@@ -1635,7 +1653,7 @@ ${content}`;
     }
 
     try {
-      const subscriberFile = path.join('content', 'hackathon-subscribers.json');
+      const subscriberFile = hackathonSubscribersPath;
       
       try {
         const data = await fs.readFile(subscriberFile, 'utf-8');


### PR DESCRIPTION
## Summary
- protect article editor routes via ProtectedRoute
- send Authorization header when updating articles
- use /tmp storage for newsletter data when DATABASE_URL is missing
- use /tmp paths for hackathon JSON files when database is absent

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68406da9d1dc8330acb4774b58c000db