### PR TITLE
Fix uploads directory creation

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -11,6 +11,7 @@ console.log('🔧 [DEBUG] SMTP_PASS:', process.env.SMTP_PASS ? '✅ Configurato'
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { storage } from "./storage";
+import { ensureUploadsDir, getUploadsDir } from './uploads';
 import cors from 'cors';
 import path from 'path';
 import fs from 'fs';
@@ -154,8 +155,9 @@ function serveStaticFiles(app: express.Express) {
   const distPath = path.resolve(process.cwd(), "dist/public");
   
   // Configurazione per servire i file uploads
-  const uploadsDir = process.env.NODE_ENV === 'production' ? '/tmp/uploads' : path.join(process.cwd(), 'public', 'uploads');
-  
+  ensureUploadsDir();
+  const uploadsDir = getUploadsDir();
+
   // Middleware per servire file uploads
   app.use('/uploads', express.static(uploadsDir));
   console.log(`📁 Servendo file uploads da: ${uploadsDir}`);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -12,34 +12,15 @@ import multer from 'multer';
 import Fuse from 'fuse.js';
 import fsSync from 'fs';
 import nodemailer from 'nodemailer';
+import { ensureUploadsDir, getUploadsDir } from './uploads';
 
 const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
 const ADMIN_USERNAME = process.env.ADMIN_USERNAME || 'admin';
 const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'admin123';
 
-// Configurazione multer per usare /tmp in produzione e public/uploads in locale
-const uploadsDir = process.env.NODE_ENV === 'production' ? '/tmp/uploads' : path.join('public', 'uploads');
-
-// Assicuriamoci che la directory esista (solo se siamo in grado di crearla)
-try {
-  if (!fsSync.existsSync(uploadsDir)) {
-    // In produzione, /tmp/uploads dovrebbe essere sempre creabile
-    // In sviluppo, creiamo public/uploads se possibile
-    fsSync.mkdirSync(uploadsDir, { recursive: true });
-    console.log(`✅ Directory uploads creata: ${uploadsDir}`);
-  } else {
-    console.log(`📁 Directory uploads già esistente: ${uploadsDir}`);
-  }
-} catch (error) {
-  console.warn('⚠️ Impossibile creare la directory uploads:', error);
-  
-  // Se in produzione e /tmp/uploads non è creabile, questo è un problema serio
-  if (process.env.NODE_ENV === 'production') {
-    console.error('❌ CRITICO: Impossibile creare directory uploads in produzione');
-  } else {
-    console.warn('⚠️ In sviluppo: uploads potrebbero non funzionare senza la directory');
-  }
-}
+// Configurazione directory uploads con fallback automatico
+ensureUploadsDir();
+const uploadsDir = getUploadsDir();
 
 // Configurazione multer con DiskStorage personalizzato per Render
 const multerStorage = multer.diskStorage({

--- a/server/uploads.ts
+++ b/server/uploads.ts
@@ -1,0 +1,29 @@
+import path from 'path';
+import fs from 'fs';
+
+let uploadsDir: string = process.env.NODE_ENV === 'production' ? '/tmp/uploads' : path.join(process.cwd(), 'public', 'uploads');
+
+export function getUploadsDir(): string {
+  return uploadsDir;
+}
+
+export function ensureUploadsDir(): void {
+  try {
+    if (!fs.existsSync(uploadsDir)) {
+      fs.mkdirSync(uploadsDir, { recursive: true });
+      console.log(`✅ Directory uploads creata: ${uploadsDir}`);
+    }
+  } catch (err: any) {
+    console.warn('⚠️ Impossibile creare la directory uploads:', err);
+    const fallbackDir = '/tmp/uploads';
+    if (uploadsDir !== fallbackDir) {
+      try {
+        fs.mkdirSync(fallbackDir, { recursive: true });
+        uploadsDir = fallbackDir;
+        console.log(`📂 Directory uploads fallback: ${uploadsDir}`);
+      } catch (fallbackErr) {
+        console.error('❌ Impossibile creare directory di fallback per uploads:', fallbackErr);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- handle uploads directory path centrally with fallback to `/tmp/uploads`
- use new helper to configure multer and static uploads path

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6842e838d9d08330a1886378736f38da